### PR TITLE
Improve worker coverage with Redis-backed integration tests

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -21,6 +21,8 @@ services:
     depends_on:
       mysql-test: # Wait for mysql-test to be healthy
         condition: service_healthy
+      redis:
+        condition: service_healthy
       minio: # Wait for minio to be healthy
         condition: service_healthy
       create-bucket: # Wait for the bucket creation task to complete
@@ -82,5 +84,16 @@ services:
       mc alias set --api S3v4 local http://minio:19000 $$MINIO_ACCESS_KEY $$MINIO_SECRET_KEY &&
       mc mb --ignore-existing local/gratheon-test &&
       mc anonymous set download local/gratheon-test
+
+  redis:
+    image: redis:8-alpine
+    command: redis-server --requirepass pass
+    ports:
+      - 16379:6379
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "pass", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
 volumes:
   mysql82:

--- a/src/redisPubSub.ts
+++ b/src/redisPubSub.ts
@@ -4,16 +4,17 @@ import Redis from "ioredis";
 let subscriberInstance: Redis;
 let publisherInstance: Redis;
 
-export const subscriber = () => {
-	if(subscriberInstance){
-		return subscriberInstance
-	}
+function getRedisConfig() {
+	const host = process.env.REDIS_HOST || (process.env.ENV_ID === "prod" ? "127.0.0.1" : "redis");
+	const port = Number(process.env.REDIS_PORT || 6379);
+	const username = process.env.REDIS_USERNAME || "default";
+	const password = process.env.REDIS_PASSWORD || "pass";
 
-	subscriberInstance = new Redis({
-		port: 6379,
-		host: process.env.ENV_ID === "prod" ? "127.0.0.1" : "redis",
-		username: "default",
-		password: "pass",
+	return {
+		port,
+		host,
+		username,
+		password,
 		showFriendlyErrorStack: true,
 		db: 0,
 
@@ -22,7 +23,15 @@ export const subscriber = () => {
 		retryStrategy: (times) => {
 			return Math.min(times * 500, 5000);
 		},
-	});
+	};
+}
+
+export const subscriber = () => {
+	if(subscriberInstance){
+		return subscriberInstance
+	}
+
+	subscriberInstance = new Redis(getRedisConfig());
 
 	return subscriberInstance
 }
@@ -32,20 +41,7 @@ export const publisher = () => {
 		return publisherInstance
 	}
 
-	publisherInstance = new Redis({
-		port: 6379,
-		host: process.env.ENV_ID === "prod" ? "127.0.0.1" : "redis",
-		username: "default",
-		password: "pass",
-		showFriendlyErrorStack: true,
-		db: 0,
-
-		enableReadyCheck: true,
-		autoResubscribe: true,
-		retryStrategy: (times) => {
-			return Math.min(times * 500, 5000);
-		},
-	})
+	publisherInstance = new Redis(getRedisConfig())
 
 	return publisherInstance
 }

--- a/src/workers/detectCells.test.ts
+++ b/src/workers/detectCells.test.ts
@@ -1,0 +1,28 @@
+import { convertDetectedResourcesStorageFormat } from './detectCells';
+
+describe('detectCells helpers', () => {
+  test('convertDetectedResourcesStorageFormat normalizes and rounds values', () => {
+    const result = convertDetectedResourcesStorageFormat(
+      [
+        [500, 250, 100, 2, 0, 0.913],
+      ],
+      1000,
+      500,
+    );
+
+    expect(result).toEqual([
+      [
+        2,
+        0.5,
+        0.5,
+        0.1,
+        92,
+      ],
+    ]);
+  });
+
+  test('convertDetectedResourcesStorageFormat returns empty array on invalid input', () => {
+    const result = convertDetectedResourcesStorageFormat(null as any, 1000, 500);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/workers/detectVarroa.test.ts
+++ b/src/workers/detectVarroa.test.ts
@@ -51,4 +51,62 @@ describe("detectVarroa bee-crop mapping", () => {
     expect(mapped!.w).toBeCloseTo(0.04, 4);
     expect(mapped!.h).toBeCloseTo(0.02, 4);
   });
+
+  test("buildBeeCropBounds returns null for non-finite bee values", () => {
+    const crop = buildBeeCropBounds(
+      {
+        n: "0",
+        x: Number.NaN,
+        y: 0.5,
+        w: 0.1,
+        h: 0.1,
+        c: 0.9,
+      },
+      1000,
+      1000,
+    );
+
+    expect(crop).toBeNull();
+  });
+
+  test("mapVarroaDetectionToOriginal returns null for invalid or zero-area boxes", () => {
+    const invalid = mapVarroaDetectionToOriginal(
+      {
+        x1: Number.NaN,
+        y1: 10,
+        x2: 50,
+        y2: 20,
+        confidence: 0.9,
+      },
+      {
+        left: 10,
+        top: 20,
+        width: 100,
+        height: 100,
+      },
+      1000,
+      1000,
+    );
+
+    const zeroArea = mapVarroaDetectionToOriginal(
+      {
+        x1: 20,
+        y1: 20,
+        x2: 20,
+        y2: 40,
+        confidence: 0.9,
+      },
+      {
+        left: 10,
+        top: 20,
+        width: 100,
+        height: 100,
+      },
+      1000,
+      1000,
+    );
+
+    expect(invalid).toBeNull();
+    expect(zeroArea).toBeNull();
+  });
 });

--- a/src/workers/detectVarroaBottom.test.ts
+++ b/src/workers/detectVarroaBottom.test.ts
@@ -1,144 +1,81 @@
-import { describe, it, expect } from '@jest/globals';
+import {
+    normalizeVarroaBottomDetection,
+    normalizeVarroaBottomDetections,
+} from './detectVarroaBottom';
 
-describe('Varroa Bottom Detection Coordinate Normalization', () => {
-    it('should normalize pixel coordinates to 0-1 range', () => {
-        const imageWidth = 4032;
-        const imageHeight = 3024;
+describe('detectVarroaBottom normalization helpers', () => {
+    it('normalizes pixel coordinates to 0-1 range with expected rounding', () => {
+        const normalized = normalizeVarroaBottomDetection(
+            {
+                x1: 2193.93,
+                y1: 1836.99,
+                x2: 2257.26,
+                y2: 1905.63,
+                confidence: 0.9199939370155334,
+            },
+            {
+                width: 4032,
+                height: 3024,
+            }
+        );
 
-        const rawDetection = {
-            x1: 2193.93,
-            y1: 1836.99,
-            x2: 2257.26,
-            y2: 1905.63,
-            confidence: 0.92
-        };
-
-        const centerX = (rawDetection.x1 + rawDetection.x2) / 2;
-        const centerY = (rawDetection.y1 + rawDetection.y2) / 2;
-        const width = rawDetection.x2 - rawDetection.x1;
-
-        const normalized = {
-            x: parseFloat((centerX / imageWidth).toFixed(4)),
-            y: parseFloat((centerY / imageHeight).toFixed(4)),
-            w: parseFloat((width / imageWidth).toFixed(4)),
-            c: parseFloat(rawDetection.confidence.toFixed(2))
-        };
-
-        expect(normalized.x).toBeGreaterThanOrEqual(0);
-        expect(normalized.x).toBeLessThanOrEqual(1);
-        expect(normalized.y).toBeGreaterThanOrEqual(0);
-        expect(normalized.y).toBeLessThanOrEqual(1);
-        expect(normalized.w).toBeGreaterThanOrEqual(0);
-        expect(normalized.w).toBeLessThanOrEqual(1);
-        expect(normalized.c).toBeGreaterThanOrEqual(0);
-        expect(normalized.c).toBeLessThanOrEqual(1);
-
-        expect(normalized.x).toBeCloseTo(0.552, 3);
-        expect(normalized.y).toBeCloseTo(0.6188, 4);
-        expect(normalized.w).toBeCloseTo(0.0157, 4);
-        expect(normalized.c).toBe(0.92);
+        expect(normalized).toEqual({
+            x: 0.552,
+            y: 0.6188,
+            w: 0.0157,
+            c: 0.92,
+        });
     });
 
-    it('should handle edge case at image boundaries', () => {
-        const imageWidth = 4032;
-        const imageHeight = 3024;
+    it('returns null when image dimensions are invalid', () => {
+        const normalized = normalizeVarroaBottomDetection(
+            {
+                x1: 10,
+                y1: 10,
+                x2: 20,
+                y2: 20,
+                confidence: 0.9,
+            },
+            {
+                width: 0,
+                height: 1000,
+            }
+        );
 
-        const rawDetection = {
-            x1: 0,
-            y1: 0,
-            x2: 50,
-            y2: 50,
-            confidence: 0.85
-        };
-
-        const centerX = (rawDetection.x1 + rawDetection.x2) / 2;
-        const centerY = (rawDetection.y1 + rawDetection.y2) / 2;
-        const width = rawDetection.x2 - rawDetection.x1;
-
-        const normalized = {
-            x: parseFloat((centerX / imageWidth).toFixed(4)),
-            y: parseFloat((centerY / imageHeight).toFixed(4)),
-            w: parseFloat((width / imageWidth).toFixed(4)),
-            c: parseFloat(rawDetection.confidence.toFixed(2))
-        };
-
-        expect(normalized.x).toBeGreaterThanOrEqual(0);
-        expect(normalized.y).toBeGreaterThanOrEqual(0);
-        expect(normalized.w).toBeGreaterThanOrEqual(0);
+        expect(normalized).toBeNull();
     });
 
-    it('should round to reasonable precision (4 decimals for coords, 2 for confidence)', () => {
-        const imageWidth = 4032;
-        const imageHeight = 3024;
+    it('skips invalid detections in batch conversion', () => {
+        const result = normalizeVarroaBottomDetections(
+            [
+                {
+                    x1: 0,
+                    y1: 0,
+                    x2: 50,
+                    y2: 50,
+                    confidence: 0.85,
+                },
+                {
+                    x1: Number.NaN,
+                    y1: 0,
+                    x2: 100,
+                    y2: 100,
+                    confidence: 0.9,
+                },
+            ],
+            {
+                width: 1000,
+                height: 1000,
+            }
+        );
 
-        const rawDetection = {
-            x1: 2193.9312341234,
-            y1: 1836.9987654321,
-            x2: 2257.2623456789,
-            y2: 1905.6345678901,
-            confidence: 0.9199939370155334
-        };
-
-        const centerX = (rawDetection.x1 + rawDetection.x2) / 2;
-        const centerY = (rawDetection.y1 + rawDetection.y2) / 2;
-        const width = rawDetection.x2 - rawDetection.x1;
-
-        const normalized = {
-            x: parseFloat((centerX / imageWidth).toFixed(4)),
-            y: parseFloat((centerY / imageHeight).toFixed(4)),
-            w: parseFloat((width / imageWidth).toFixed(4)),
-            c: parseFloat(rawDetection.confidence.toFixed(2))
-        };
-
-        const xStr = normalized.x.toString();
-        const yStr = normalized.y.toString();
-        const wStr = normalized.w.toString();
-        const cStr = normalized.c.toString();
-
-        expect(xStr.split('.')[1]?.length || 0).toBeLessThanOrEqual(4);
-        expect(yStr.split('.')[1]?.length || 0).toBeLessThanOrEqual(4);
-        expect(wStr.split('.')[1]?.length || 0).toBeLessThanOrEqual(4);
-        expect(cStr.split('.')[1]?.length || 0).toBeLessThanOrEqual(2);
-    });
-
-    it('should fail if coordinates exceed 1 (indicating wrong normalization)', () => {
-        const imageWidth = 1000;
-        const imageHeight = 1000;
-
-        const rawDetection = {
-            x1: 500,
-            y1: 500,
-            x2: 600,
-            y2: 600,
-            confidence: 0.92
-        };
-
-        const centerX = (rawDetection.x1 + rawDetection.x2) / 2;
-        const centerY = (rawDetection.y1 + rawDetection.y2) / 2;
-        const width = rawDetection.x2 - rawDetection.x1;
-
-        const normalized = {
-            x: parseFloat((centerX / imageWidth).toFixed(4)),
-            y: parseFloat((centerY / imageHeight).toFixed(4)),
-            w: parseFloat((width / imageWidth).toFixed(4)),
-            c: parseFloat(rawDetection.confidence.toFixed(2))
-        };
-
-        expect(normalized.x).toBeLessThanOrEqual(1);
-        expect(normalized.y).toBeLessThanOrEqual(1);
-        expect(normalized.w).toBeLessThanOrEqual(1);
-    });
-
-    it('should demonstrate the bug from production data', () => {
-        const buggyData = {
-            c: 0.9199939370155334,
-            w: 0.020630915959676106,
-            x: 1.2347479263941448,
-            y: 0.7448616921901703
-        };
-
-        expect(buggyData.x).toBeGreaterThan(1); // This shows the bug!
-        expect(buggyData.c).toBeCloseTo(0.92, 2); // Should be rounded
+        expect(result).toEqual([
+            {
+                x: 0.025,
+                y: 0.025,
+                w: 0.05,
+                c: 0.85,
+            },
+        ]);
     });
 });
-

--- a/src/workers/detectVarroaBottom.ts
+++ b/src/workers/detectVarroaBottom.ts
@@ -10,6 +10,59 @@ import { generateChannelName, publisher } from '../redisPubSub';
 import * as imageModel from '../models/image';
 import { resolveThresholdFromPayload } from "../models/detectionSettings";
 
+type VarroaBottomRawDetection = {
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+    confidence: number;
+};
+
+type ImageDimensions = {
+    width: number;
+    height: number;
+};
+
+export type NormalizedVarroaBottomDetection = {
+    x: number;
+    y: number;
+    w: number;
+    c: number;
+};
+
+export function normalizeVarroaBottomDetection(
+    detection: VarroaBottomRawDetection,
+    dimensions: ImageDimensions
+): NormalizedVarroaBottomDetection | null {
+    if (!dimensions.width || !dimensions.height) {
+        return null;
+    }
+
+    const centerX = (detection.x1 + detection.x2) / 2;
+    const centerY = (detection.y1 + detection.y2) / 2;
+    const width = detection.x2 - detection.x1;
+
+    if (!Number.isFinite(centerX) || !Number.isFinite(centerY) || !Number.isFinite(width) || !Number.isFinite(detection.confidence)) {
+        return null;
+    }
+
+    return {
+        x: parseFloat((centerX / dimensions.width).toFixed(4)),
+        y: parseFloat((centerY / dimensions.height).toFixed(4)),
+        w: parseFloat((width / dimensions.width).toFixed(4)),
+        c: parseFloat(detection.confidence.toFixed(2))
+    };
+}
+
+export function normalizeVarroaBottomDetections(
+    detections: VarroaBottomRawDetection[],
+    dimensions: ImageDimensions
+): NormalizedVarroaBottomDetection[] {
+    return detections
+        .map((d) => normalizeVarroaBottomDetection(d, dimensions))
+        .filter((d): d is NormalizedVarroaBottomDetection => d !== null);
+}
+
 export async function detectVarroaBottom(fileId: number, payload: any) {
     const boxFile = await boxFileModel.getBoxFileByFileId(fileId);
     const minConfidence = resolveThresholdFromPayload(payload, "varroaBottom");
@@ -94,19 +147,14 @@ export async function detectVarroaBottom(fileId: number, payload: any) {
             height: dimensions.height
         });
 
-        const detections = filteredResult.map((d, index) => {
-            const centerX = (d.x1 + d.x2) / 2;
-            const centerY = (d.y1 + d.y2) / 2;
-            const width = d.x2 - d.x1;
+        const detections = normalizeVarroaBottomDetections(filteredResult, dimensions);
 
-            const normalized = {
-                x: parseFloat((centerX / dimensions.width).toFixed(4)),
-                y: parseFloat((centerY / dimensions.height).toFixed(4)),
-                w: parseFloat((width / dimensions.width).toFixed(4)),
-                c: parseFloat(d.confidence.toFixed(2))
-            };
-
+        filteredResult.forEach((d, index) => {
             if (index === 0) {
+                const centerX = (d.x1 + d.x2) / 2;
+                const centerY = (d.y1 + d.y2) / 2;
+                const width = d.x2 - d.x1;
+                const normalized = normalizeVarroaBottomDetection(d, dimensions);
                 logger.info('detectVarroaBottom - first detection normalization', {
                     fileId,
                     rawDetection: { x1: d.x1, y1: d.y1, x2: d.x2, y2: d.y2, confidence: d.confidence },
@@ -115,8 +163,6 @@ export async function detectVarroaBottom(fileId: number, payload: any) {
                     normalized
                 });
             }
-
-            return normalized;
         });
 
         logger.info('detectVarroaBottom - normalized detections', {

--- a/test/integration/setup-env.ts
+++ b/test/integration/setup-env.ts
@@ -9,3 +9,7 @@ process.env.MYSQL_DATABASE = process.env.MYSQL_DATABASE || 'image-splitter';
 
 process.env.AWS_TARGET_UPLOAD_ENDPOINT = process.env.AWS_TARGET_UPLOAD_ENDPOINT || 'http://localhost:19000/';
 process.env.AWS_PUBLIC_URL = process.env.AWS_PUBLIC_URL || 'http://localhost:19000/gratheon-test/';
+process.env.REDIS_HOST = process.env.REDIS_HOST || '127.0.0.1';
+process.env.REDIS_PORT = process.env.REDIS_PORT || '16379';
+process.env.REDIS_USERNAME = process.env.REDIS_USERNAME || 'default';
+process.env.REDIS_PASSWORD = process.env.REDIS_PASSWORD || 'pass';

--- a/test/integration/workers/detectBees.redis.test.ts
+++ b/test/integration/workers/detectBees.redis.test.ts
@@ -1,0 +1,155 @@
+import Redis from 'ioredis';
+
+jest.mock('node-fetch', () => jest.fn());
+
+jest.mock('../../../src/models/frameSide', () => ({
+  __esModule: true,
+  default: {
+    getFrameSideByFileId: jest.fn(),
+    updateDetectedBees: jest.fn(),
+    getWorkerBeeCount: jest.fn(),
+    getDroneCount: jest.fn(),
+    getQueenCount: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/models/jobs', () => ({
+  __esModule: true,
+  TYPE_BEES: 'bees',
+  NOTIFY_JOB: 'notify',
+  default: {
+    addJob: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/workers/common/downloadFile', () => ({
+  downloadS3FileToLocalTmp: jest.fn(),
+}));
+
+jest.mock('../../../src/workers/common/common', () => {
+  const actual = jest.requireActual('../../../src/workers/common/common');
+  return {
+    ...actual,
+    splitIn9ImagesAndDetect: jest.fn(),
+  };
+});
+
+import fetch from 'node-fetch';
+import frameSideModel from '../../../src/models/frameSide';
+import jobs from '../../../src/models/jobs';
+import { splitIn9ImagesAndDetect } from '../../../src/workers/common/common';
+import { detectWorkerBees } from '../../../src/workers/detectBees';
+
+async function waitForMessage(redis: Redis, channel: string, timeoutMs = 5000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      redis.removeListener('message', onMessage);
+      reject(new Error(`Timed out waiting for Redis message on ${channel}`));
+    }, timeoutMs);
+
+    const onMessage = (messageChannel: string, message: string) => {
+      if (messageChannel !== channel) return;
+      clearTimeout(timeout);
+      redis.removeListener('message', onMessage);
+      resolve(message);
+    };
+
+    redis.on('message', onMessage);
+  });
+}
+
+describe('detectWorkerBees Redis integration', () => {
+  const redisClient = new Redis({
+    host: process.env.REDIS_HOST || '127.0.0.1',
+    port: Number(process.env.REDIS_PORT || 6379),
+    username: process.env.REDIS_USERNAME || 'default',
+    password: process.env.REDIS_PASSWORD || 'pass',
+    db: 0,
+  });
+
+  afterAll(async () => {
+    const { publisher, subscriber } = await import('../../../src/redisPubSub');
+    publisher().disconnect();
+    subscriber().disconnect();
+    await redisClient.quit();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('publishes partial bee detections and enqueues final completion notify job', async () => {
+    const mockFile = {
+      file_id: 101,
+      frame_side_id: 201,
+      user_id: 301,
+      width: 1000,
+      height: 1000,
+      filename: 'frame.jpg',
+      localFilePath: '/tmp/frame.jpg',
+    };
+
+    (frameSideModel.getFrameSideByFileId as jest.Mock).mockResolvedValue(mockFile);
+    (frameSideModel.updateDetectedBees as jest.Mock).mockResolvedValue(undefined);
+    (frameSideModel.getWorkerBeeCount as jest.Mock).mockResolvedValue(12);
+    (frameSideModel.getDroneCount as jest.Mock).mockResolvedValue(3);
+    (frameSideModel.getQueenCount as jest.Mock).mockResolvedValue(1);
+
+    (splitIn9ImagesAndDetect as jest.Mock).mockImplementation(async (_file, _chunkSize, callback) => {
+      await callback(Buffer.from('chunk'), { x: 1, y: 1, left: 100, top: 50 }, mockFile.file_id, mockFile.filename);
+    });
+
+    (fetch as unknown as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        result: [
+          { class_id: 0, class_name: 'worker', confidence: 0.88, box: [10, 20, 50, 60] },
+          { class_id: 3, class_name: 'queen', confidence: 0.99, box: [100, 100, 140, 160] },
+          { class_id: 1, class_name: 'drone', confidence: 0.2, box: [20, 20, 40, 40] },
+        ],
+      }),
+    });
+
+    const partialChannel = `${mockFile.user_id}.frame_side.${mockFile.frame_side_id}.bees_partially_detected`;
+    await redisClient.subscribe(partialChannel);
+    const messagePromise = waitForMessage(redisClient, partialChannel);
+
+    await detectWorkerBees(mockFile.file_id, {
+      detectionThresholds: { bees: 0.6 },
+    });
+
+    const message = JSON.parse(await messagePromise);
+
+    expect(frameSideModel.updateDetectedBees).toHaveBeenCalledWith(
+      [{ n: '0', x: 0.13, y: 0.09, w: 0.04, h: 0.04, c: 0.88 }],
+      mockFile.file_id,
+      mockFile.frame_side_id,
+      mockFile.user_id,
+    );
+
+    expect(message).toEqual({
+      delta: [{ n: '0', x: 0.13, y: 0.09, w: 0.04, h: 0.04, c: 0.88 }],
+      detectedWorkerBeeCount: 12,
+      detectedDroneCount: 3,
+      detectedQueenCount: 1,
+      isBeeDetectionComplete: false,
+    });
+
+    expect(jobs.addJob).toHaveBeenCalledWith(
+      'notify',
+      mockFile.file_id,
+      {
+        redisChannelName: `${mockFile.user_id}.frame_side.${mockFile.frame_side_id}.bees_detected`,
+        payload: {
+          detectedWorkerBeeCount: 12,
+          detectedDroneCount: 3,
+          detectedQueenCount: 1,
+          isBeeDetectionComplete: true,
+        },
+      },
+      1,
+    );
+
+    await redisClient.unsubscribe(partialChannel);
+  });
+});

--- a/test/integration/workers/detectCells.redis.test.ts
+++ b/test/integration/workers/detectCells.redis.test.ts
@@ -1,0 +1,155 @@
+import Redis from 'ioredis';
+import fs from 'fs';
+
+jest.mock('node-fetch', () => jest.fn());
+
+jest.mock('../../../src/models/frameSideCells', () => ({
+  __esModule: true,
+  default: {
+    getCellsByFileId: jest.fn(),
+    updateDetectedCells: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/models/jobs', () => ({
+  __esModule: true,
+  NOTIFY_JOB: 'notify',
+  default: {
+    addJob: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/workers/common/downloadFile', () => ({
+  downloadS3FileToLocalTmp: jest.fn(),
+}));
+
+import fetch from 'node-fetch';
+import frameSideCells from '../../../src/models/frameSideCells';
+import jobs from '../../../src/models/jobs';
+import { analyzeCells } from '../../../src/workers/detectCells';
+
+async function waitForMessage(redis: Redis, channel: string, timeoutMs = 5000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      redis.removeListener('message', onMessage);
+      reject(new Error(`Timed out waiting for Redis message on ${channel}`));
+    }, timeoutMs);
+
+    const onMessage = (messageChannel: string, message: string) => {
+      if (messageChannel !== channel) return;
+      clearTimeout(timeout);
+      redis.removeListener('message', onMessage);
+      resolve(message);
+    };
+
+    redis.on('message', onMessage);
+  });
+}
+
+describe('analyzeCells Redis integration', () => {
+  const redisClient = new Redis({
+    host: process.env.REDIS_HOST || '127.0.0.1',
+    port: Number(process.env.REDIS_PORT || 6379),
+    username: process.env.REDIS_USERNAME || 'default',
+    password: process.env.REDIS_PASSWORD || 'pass',
+    db: 0,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(Buffer.from('image-bytes') as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    const { publisher, subscriber } = await import('../../../src/redisPubSub');
+    publisher().disconnect();
+    subscriber().disconnect();
+    await redisClient.quit();
+  });
+
+  it('publishes converted cells result and enqueues hive notify job', async () => {
+    const mockFile = {
+      file_id: 121,
+      frame_side_id: 221,
+      user_id: 321,
+      hive_id: 421,
+      width: 1000,
+      height: 500,
+      filename: 'cells.jpg',
+      localFilePath: '/tmp/cells.jpg',
+    };
+
+    (frameSideCells.getCellsByFileId as jest.Mock).mockResolvedValue(mockFile);
+    (frameSideCells.updateDetectedCells as jest.Mock).mockResolvedValue({
+      brood: 10,
+      drone_brood: 11,
+      capped_brood: 12,
+      eggs: 13,
+      nectar: 14,
+      pollen: 15,
+      honey: 16,
+    });
+
+    (fetch as unknown as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        result: [
+          [500, 250, 100, 2, 0, 0.913],
+        ],
+      }),
+    });
+
+    const channel = `${mockFile.user_id}.frame_side.${mockFile.frame_side_id}.frame_resources_detected`;
+    await redisClient.subscribe(channel);
+    const messagePromise = waitForMessage(redisClient, channel);
+
+    await analyzeCells(mockFile.file_id, {});
+
+    const message = JSON.parse(await messagePromise);
+
+    expect(frameSideCells.updateDetectedCells).toHaveBeenCalledWith(
+      [[2, 0.5, 0.5, 0.1, 92]],
+      mockFile.file_id,
+      mockFile.frame_side_id,
+    );
+
+    expect(message).toEqual({
+      delta: [[2, 0.5, 0.5, 0.1, 92]],
+      isCellsDetectionComplete: true,
+      broodPercent: 10,
+      droneBroodPercent: 11,
+      cappedBroodPercent: 12,
+      eggsPercent: 13,
+      nectarPercent: 14,
+      pollenPercent: 15,
+      honeyPercent: 16,
+    });
+
+    expect(jobs.addJob).toHaveBeenCalledWith(
+      'notify',
+      mockFile.file_id,
+      {
+        redisChannelName: `${mockFile.user_id}.hive.${mockFile.hive_id}.frame_resources_detected`,
+        payload: {
+          delta: [[2, 0.5, 0.5, 0.1, 92]],
+          isCellsDetectionComplete: true,
+          frameSideId: mockFile.frame_side_id,
+          broodPercent: 10,
+          droneBroodPercent: 11,
+          cappedBroodPercent: 12,
+          eggsPercent: 13,
+          nectarPercent: 14,
+          pollenPercent: 15,
+          honeyPercent: 16,
+        },
+      },
+      1,
+    );
+
+    await redisClient.unsubscribe(channel);
+  });
+});

--- a/test/integration/workers/detectDrones.redis.test.ts
+++ b/test/integration/workers/detectDrones.redis.test.ts
@@ -1,0 +1,158 @@
+import Redis from 'ioredis';
+
+jest.mock('node-fetch', () => jest.fn());
+
+jest.mock('../../../src/models/frameSide', () => ({
+  __esModule: true,
+  default: {
+    getFrameSideByFileId: jest.fn(),
+    updateDetectedDrones: jest.fn(),
+    getWorkerBeeCount: jest.fn(),
+    getDroneCount: jest.fn(),
+    getQueenCount: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/models/jobs', () => ({
+  __esModule: true,
+  NOTIFY_JOB: 'notify',
+  default: {
+    addJob: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/workers/common/downloadFile', () => ({
+  downloadS3FileToLocalTmp: jest.fn(),
+}));
+
+jest.mock('../../../src/workers/common/common', () => {
+  const actual = jest.requireActual('../../../src/workers/common/common');
+  return {
+    ...actual,
+    splitIn9ImagesAndDetect: jest.fn(),
+  };
+});
+
+import fetch from 'node-fetch';
+import frameSideModel from '../../../src/models/frameSide';
+import jobs from '../../../src/models/jobs';
+import { splitIn9ImagesAndDetect } from '../../../src/workers/common/common';
+import { detectDrones } from '../../../src/workers/detectDrones';
+
+async function waitForMessage(redis: Redis, channel: string, timeoutMs = 5000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      redis.removeListener('message', onMessage);
+      reject(new Error(`Timed out waiting for Redis message on ${channel}`));
+    }, timeoutMs);
+
+    const onMessage = (messageChannel: string, message: string) => {
+      if (messageChannel !== channel) return;
+      clearTimeout(timeout);
+      redis.removeListener('message', onMessage);
+      resolve(message);
+    };
+
+    redis.on('message', onMessage);
+  });
+}
+
+describe('detectDrones Redis integration', () => {
+  const redisClient = new Redis({
+    host: process.env.REDIS_HOST || '127.0.0.1',
+    port: Number(process.env.REDIS_PORT || 6379),
+    username: process.env.REDIS_USERNAME || 'default',
+    password: process.env.REDIS_PASSWORD || 'pass',
+    db: 0,
+  });
+
+  afterAll(async () => {
+    const { publisher, subscriber } = await import('../../../src/redisPubSub');
+    publisher().disconnect();
+    subscriber().disconnect();
+    await redisClient.quit();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('publishes partial drone detections and enqueues final completion notify job', async () => {
+    const mockFile = {
+      file_id: 111,
+      frame_side_id: 211,
+      user_id: 311,
+      width: 1000,
+      height: 1000,
+      filename: 'frame.jpg',
+      localFilePath: '/tmp/frame.jpg',
+    };
+
+    (frameSideModel.getFrameSideByFileId as jest.Mock).mockResolvedValue(mockFile);
+    (frameSideModel.updateDetectedDrones as jest.Mock).mockResolvedValue(undefined);
+    (frameSideModel.getWorkerBeeCount as jest.Mock).mockResolvedValue(14);
+    (frameSideModel.getDroneCount as jest.Mock).mockResolvedValue(4);
+    (frameSideModel.getQueenCount as jest.Mock).mockResolvedValue(1);
+
+    (splitIn9ImagesAndDetect as jest.Mock).mockImplementation(async (_file, _chunkSize, callback) => {
+      await callback(Buffer.from('chunk'), { x: 1, y: 1, left: 100, top: 50 }, mockFile.file_id, mockFile.filename);
+    });
+
+    (fetch as unknown as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        result: [
+          { class: 1, class_name: 'drone', confidence: 0.91, x1: 10, y1: 20, x2: 50, y2: 60 },
+          { class: 0, class_name: 'worker', confidence: 0.98, x1: 5, y1: 5, x2: 30, y2: 30 },
+        ],
+        count: 2,
+        worker_count: 1,
+        drone_count: 1,
+      }),
+    });
+
+    const partialChannel = `${mockFile.user_id}.frame_side.${mockFile.frame_side_id}.bees_partially_detected`;
+    await redisClient.subscribe(partialChannel);
+    const messagePromise = waitForMessage(redisClient, partialChannel);
+
+    await detectDrones(mockFile.file_id, {
+      detectionThresholds: { drones: 0.6 },
+    });
+
+    const message = JSON.parse(await messagePromise);
+
+    expect(frameSideModel.updateDetectedDrones).toHaveBeenCalledWith(
+      [{ n: '1', x: 0.13, y: 0.09, w: 0.04, h: 0.04, c: 0.91 }],
+      mockFile.file_id,
+      mockFile.frame_side_id,
+      mockFile.user_id,
+    );
+
+    expect(message).toEqual({
+      delta: [{ n: '1', x: 0.13, y: 0.09, w: 0.04, h: 0.04, c: 0.91 }],
+      detectedDroneCount: 4,
+      detectedWorkerBeeCount: 14,
+      detectedQueenCount: 1,
+      isBeeDetectionComplete: false,
+    });
+
+    expect(jobs.addJob).toHaveBeenCalledWith(
+      'notify',
+      mockFile.file_id,
+      {
+        redisChannelName: `${mockFile.user_id}.frame_side.${mockFile.frame_side_id}.bees_detected`,
+        payload: {
+          detectedWorkerBeeCount: 14,
+          detectedDroneCount: 4,
+          detectedQueenCount: 1,
+          isBeeDetectionComplete: true,
+          isDroneDetectionComplete: true,
+        },
+      },
+      1,
+    );
+
+    await redisClient.unsubscribe(partialChannel);
+  });
+});

--- a/test/integration/workers/detectVarroa.redis.test.ts
+++ b/test/integration/workers/detectVarroa.redis.test.ts
@@ -1,0 +1,101 @@
+import Redis from 'ioredis';
+
+jest.mock('../../../src/models/frameSide', () => ({
+  __esModule: true,
+  default: {
+    getFrameSideByFileId: jest.fn(),
+    getDetectedBees: jest.fn(),
+    updateDetectedVarroa: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/models/storage', () => ({
+  storage: jest.fn(() => ({ query: jest.fn() })),
+}));
+
+jest.mock('../../../src/workers/common/downloadFile', () => ({
+  downloadS3FileToLocalTmp: jest.fn(),
+}));
+
+import frameSideModel from '../../../src/models/frameSide';
+import { detectVarroa } from '../../../src/workers/detectVarroa';
+
+async function waitForMessage(redis: Redis, channel: string, timeoutMs = 5000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      redis.removeListener('message', onMessage);
+      reject(new Error(`Timed out waiting for Redis message on ${channel}`));
+    }, timeoutMs);
+
+    const onMessage = (messageChannel: string, message: string) => {
+      if (messageChannel !== channel) return;
+      clearTimeout(timeout);
+      redis.removeListener('message', onMessage);
+      resolve(message);
+    };
+
+    redis.on('message', onMessage);
+  });
+}
+
+describe('detectVarroa Redis integration', () => {
+  const redisClient = new Redis({
+    host: process.env.REDIS_HOST || '127.0.0.1',
+    port: Number(process.env.REDIS_PORT || 6379),
+    username: process.env.REDIS_USERNAME || 'default',
+    password: process.env.REDIS_PASSWORD || 'pass',
+    db: 0,
+  });
+
+  afterAll(async () => {
+    const { publisher, subscriber } = await import('../../../src/redisPubSub');
+    publisher().disconnect();
+    subscriber().disconnect();
+    await redisClient.quit();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('publishes zero varroa result when no bee detections exist', async () => {
+    const mockFile = {
+      file_id: 901,
+      frame_side_id: 701,
+      user_id: 501,
+      width: 2000,
+      height: 1500,
+      localFilePath: '/tmp/non-existent.jpg',
+    };
+
+    (frameSideModel.getFrameSideByFileId as jest.Mock).mockResolvedValue(mockFile);
+    (frameSideModel.getDetectedBees as jest.Mock).mockResolvedValue([]);
+    (frameSideModel.updateDetectedVarroa as jest.Mock).mockResolvedValue(undefined);
+
+    const channel = `${mockFile.user_id}.frame_side.${mockFile.frame_side_id}.varroa_detected`;
+    await redisClient.subscribe(channel);
+
+    const messagePromise = waitForMessage(redisClient, channel);
+
+    await detectVarroa(mockFile.file_id, {
+      detectionThresholds: { varroa: 0.9 },
+    });
+
+    const message = await messagePromise;
+
+    expect(frameSideModel.updateDetectedVarroa).toHaveBeenCalledWith(
+      [],
+      mockFile.file_id,
+      mockFile.frame_side_id,
+      mockFile.user_id,
+    );
+
+    expect(JSON.parse(message)).toEqual({
+      delta: [],
+      isVarroaDetectionComplete: true,
+      varroaCount: 0,
+    });
+
+    await redisClient.unsubscribe(channel);
+  });
+});

--- a/test/integration/workers/detectVarroaBottom.redis.test.ts
+++ b/test/integration/workers/detectVarroaBottom.redis.test.ts
@@ -1,0 +1,139 @@
+import Redis from 'ioredis';
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+jest.mock('sharp', () => {
+  return jest.fn(() => ({
+    metadata: jest.fn().mockResolvedValue({ width: 100, height: 200 }),
+  }));
+});
+
+jest.mock('../../../src/models/boxFile', () => ({
+  __esModule: true,
+  default: {
+    getBoxFileByFileId: jest.fn(),
+    updateVarroaDetections: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/models/image', () => ({
+  getOriginalFileLocalPath: jest.fn(() => '/tmp/box-file.jpg'),
+}));
+
+jest.mock('../../../src/workers/common/downloadFile', () => ({
+  downloadS3FileToLocalTmp: jest.fn(),
+}));
+
+import axios from 'axios';
+import fs from 'fs';
+import boxFileModel from '../../../src/models/boxFile';
+import { detectVarroaBottom } from '../../../src/workers/detectVarroaBottom';
+
+async function waitForMessage(redis: Redis, channel: string, timeoutMs = 5000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      redis.removeListener('message', onMessage);
+      reject(new Error(`Timed out waiting for Redis message on ${channel}`));
+    }, timeoutMs);
+
+    const onMessage = (messageChannel: string, message: string) => {
+      if (messageChannel !== channel) return;
+      clearTimeout(timeout);
+      redis.removeListener('message', onMessage);
+      resolve(message);
+    };
+
+    redis.on('message', onMessage);
+  });
+}
+
+describe('detectVarroaBottom Redis integration', () => {
+  const redisClient = new Redis({
+    host: process.env.REDIS_HOST || '127.0.0.1',
+    port: Number(process.env.REDIS_PORT || 6379),
+    username: process.env.REDIS_USERNAME || 'default',
+    password: process.env.REDIS_PASSWORD || 'pass',
+    db: 0,
+  });
+
+  afterAll(async () => {
+    const { publisher, subscriber } = await import('../../../src/redisPubSub');
+    publisher().disconnect();
+    subscriber().disconnect();
+    await redisClient.quit();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(Buffer.from('image-bytes') as any);
+    jest.spyOn(fs, 'statSync').mockReturnValue({ size: 2048 } as any);
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'unlinkSync').mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('publishes normalized detections and writes DB update', async () => {
+    const mockBoxFile = {
+      box_id: 77,
+      user_id: 55,
+      file_user_id: 55,
+      hash: 'abc123',
+      filename: 'bottom.jpg',
+      url: 'https://example.test/bottom.jpg',
+    };
+
+    (boxFileModel.getBoxFileByFileId as jest.Mock).mockResolvedValue(mockBoxFile);
+    (boxFileModel.updateVarroaDetections as jest.Mock).mockResolvedValue(undefined);
+
+    (axios.post as jest.Mock).mockResolvedValue({
+      data: {
+        message: 'ok',
+        result: [
+          { x1: 10, y1: 20, x2: 30, y2: 60, confidence: 0.9 },
+          { x1: 50, y1: 50, x2: 100, y2: 100, confidence: 0.4 },
+        ],
+      },
+    });
+
+    const fileId = 999;
+    const channel = `${mockBoxFile.user_id}.box.${mockBoxFile.box_id}.varroa_detected`;
+    await redisClient.subscribe(channel);
+
+    const messagePromise = waitForMessage(redisClient, channel);
+
+    await detectVarroaBottom(fileId, {
+      detectionThresholds: { varroaBottom: 0.5 },
+    });
+
+    const message = await messagePromise;
+
+    expect(boxFileModel.updateVarroaDetections).toHaveBeenCalledWith(
+      fileId,
+      mockBoxFile.box_id,
+      mockBoxFile.user_id,
+      1,
+      [{ x: 0.2, y: 0.2, w: 0.2, c: 0.9 }],
+    );
+
+    expect(JSON.parse(message)).toEqual({
+      fileId,
+      boxId: mockBoxFile.box_id,
+      varroaCount: 1,
+      detections: [{ x: 0.2, y: 0.2, w: 0.2, c: 0.9 }],
+      isComplete: true,
+    });
+
+    expect(fs.unlinkSync).toHaveBeenCalled();
+
+    await redisClient.unsubscribe(channel);
+  });
+});


### PR DESCRIPTION
## Summary\n- add Redis-backed integration tests for worker result publishing (, )\n- refactor  detection normalization into pure exported helpers for unit testing\n- expand worker unit tests for conversion/mapping edge cases\n- make Redis connection config overridable via environment variables for testability\n- add Redis service to  and wire integration test env vars\n\n## Validation\n- 
Running global teardown for unit tests...
Compiled storage module not found. Run "pnpm run build" to compile TypeScript first.
Skipping DB connection pool cleanup.
Compiled logger module not found.
Skipping logger DB connection pool cleanup.
Global teardown finished.\n- \n- 