### PR TITLE
Optimize image-splitter Docker images for dev and prod

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,14 @@ coverage
 test
 .idea
 .github
+.git
+.pnpm-store
+app
+tmp
+minio
+*.log
+Dockerfile*
+docker-compose*.yml
+README.md
+CONTRIBUTING.md
+fix-varroa-image-memory-limit.md

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,7 +8,11 @@ COPY package.json /app/
 COPY pnpm-lock.yaml /app/pnpm-lock.yaml
 COPY schema.graphql /app/schema.graphql
 
-# we have linux dependencies so need to install them in the container
-RUN npm install -g pnpm@10.29.2 && pnpm install --frozen-lockfile --config.strict-peer-dependencies=false
+# Keep dev dependencies for TypeScript/watch mode and clean package-manager
+# caches after install so the image does not carry the full download cache.
+RUN npm install -g pnpm@10.29.2 \
+  && pnpm install --frozen-lockfile --config.strict-peer-dependencies=false \
+  && npm cache clean --force \
+  && rm -rf /root/.local/share/pnpm/store /tmp/*
 
 CMD pnpm run dev-in-docker

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,8 +1,6 @@
-FROM platformatic/node-caged:25-slim
+FROM platformatic/node-caged:25-slim AS build
 
 WORKDIR /app
-
-EXPOSE 8800
 
 COPY package.json /app/
 COPY pnpm-lock.yaml /app/pnpm-lock.yaml
@@ -12,8 +10,25 @@ COPY src /app/src
 COPY migrations /app/migrations
 COPY config /app/config
 
-# we have linux dependencies so need to install them in the container
-RUN npm install -g pnpm@10.29.2 && pnpm install --frozen-lockfile --config.strict-peer-dependencies=false
-RUN pnpm run build
+RUN npm install -g pnpm@10.29.2 \
+  && pnpm install --frozen-lockfile --config.strict-peer-dependencies=false \
+  && pnpm run build \
+  && pnpm prune --prod \
+  && npm cache clean --force \
+  && rm -rf /root/.local/share/pnpm/store /tmp/*
+
+FROM platformatic/node-caged:25-slim
+
+WORKDIR /app
+
+EXPOSE 8800
+
+COPY --from=build /app/package.json /app/package.json
+COPY --from=build /app/pnpm-lock.yaml /app/pnpm-lock.yaml
+COPY --from=build /app/schema.graphql /app/schema.graphql
+COPY --from=build /app/config /app/config
+COPY --from=build /app/migrations /app/migrations
+COPY --from=build /app/app /app/app
+COPY --from=build /app/node_modules /app/node_modules
 
 CMD node --max-old-space-size=4096 ./app/image-splitter.js


### PR DESCRIPTION
## Summary
- convert the production image to a multi-stage build so the final image keeps only runtime artifacts and production dependencies
- clean npm and pnpm caches during image builds and tighten the Docker build context with a broader .dockerignore
- keep the development hot-reload workflow unchanged while reducing unnecessary image bloat

## Verification
- docker build -f Dockerfile.dev -t image-splitter:dev-opt-test .
- docker build -f Dockerfile.prod -t image-splitter:prod-opt-test .
- resulting images: dev 559MB, prod 521MB